### PR TITLE
Bump test version to v1.3.0-dev1

### DIFF
--- a/.github/workflows/cwltool.yml
+++ b/.github/workflows/cwltool.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.9.x'
       
       - name: Setup prerequirements
-        run: pip install cwltest cwltool
+        run: pip install cwltest "https://github.com/common-workflow-language/cwltool/archive/refs/heads/cwl-v1.3.zip"
       
       - name: Run tests against the reference runner
-        run: ./run_test.sh RUNNER=cwltool "EXTRA=--parallel --relax-path-checks" -j$(nproc)
+        run: ./run_test.sh RUNNER=cwltool "EXTRA=--parallel --relax-path-checks --enable-dev" -j$(nproc)

--- a/tests/anon_enum_inside_array.cwl
+++ b/tests/anon_enum_inside_array.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 inputs:
   first:

--- a/tests/anon_enum_inside_array_inside_schemadef.cwl
+++ b/tests/anon_enum_inside_array_inside_schemadef.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 requirements:
   SchemaDefRequirement:

--- a/tests/any-type-compat.cwl
+++ b/tests/any-type-compat.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 steps: []

--- a/tests/basename-fields-job.yml
+++ b/tests/basename-fields-job.yml
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 tool:
   class: File
   path: echo-tool.cwl  # could have been any file, this isn't a secret CWL feature :-)

--- a/tests/basename-fields-test.cwl
+++ b/tests/basename-fields-test.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 requirements:

--- a/tests/binding-test.cwl
+++ b/tests/binding-test.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 hints:
   - class: DockerRequirement
     dockerPull: docker.io/python:3-slim

--- a/tests/bool-empty-inputbinding.cwl
+++ b/tests/bool-empty-inputbinding.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 hints:
   - class: DockerRequirement
     dockerPull: docker.io/python:3-slim

--- a/tests/bwa-mem-tool.cwl
+++ b/tests/bwa-mem-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 class: CommandLineTool
 

--- a/tests/cat-from-dir.cwl
+++ b/tests/cat-from-dir.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   dir1: Directory

--- a/tests/cat-tool-shortcut.cwl
+++ b/tests/cat-tool-shortcut.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   - class: DockerRequirement

--- a/tests/cat-tool.cwl
+++ b/tests/cat-tool.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   file1: File

--- a/tests/cat3-from-dir.cwl
+++ b/tests/cat3-from-dir.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   dir1:
     type: Directory

--- a/tests/cat3-nodocker.cwl
+++ b/tests/cat3-nodocker.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: "Print the contents of a file to stdout using 'cat'."
 inputs:
   file1:

--- a/tests/cat3-tool-mediumcut.cwl
+++ b/tests/cat3-tool-mediumcut.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
 requirements:
   DockerRequirement:

--- a/tests/cat3-tool-shortcut.cwl
+++ b/tests/cat3-tool-shortcut.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
 requirements:
   DockerRequirement:

--- a/tests/cat3-tool.cwl
+++ b/tests/cat3-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:
   DockerRequirement:

--- a/tests/cat4-from-dir.cwl
+++ b/tests/cat4-from-dir.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   dir1:
     type: Directory

--- a/tests/cat4-tool.cwl
+++ b/tests/cat4-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container if docker is available."
 hints:
   DockerRequirement:

--- a/tests/cat5-tool.cwl
+++ b/tests/cat5-tool.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 $namespaces:
   ex: http://example.com/
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:

--- a/tests/colon:test.cwl
+++ b/tests/colon:test.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 hints:
   DockerRequirement:
     dockerPull: docker.io/bash:4.4

--- a/tests/colon_test_output.cwl
+++ b/tests/colon_test_output.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 hints:
   DockerRequirement:
     dockerPull: docker.io/bash:4.4

--- a/tests/conditionals/action.cwl
+++ b/tests/conditionals/action.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   initial_file: File
   out_file_name: string

--- a/tests/conditionals/bar.cwl
+++ b/tests/conditionals/bar.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   in1: int
 baseCommand: [echo]

--- a/tests/conditionals/cat.cwl
+++ b/tests/conditionals/cat.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   in1: int
   in2: int

--- a/tests/conditionals/cond-wf-001.cwl
+++ b/tests/conditionals/cond-wf-001.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   val: int
 

--- a/tests/conditionals/cond-wf-001_nojs.cwl
+++ b/tests/conditionals/cond-wf-001_nojs.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   test: boolean
 

--- a/tests/conditionals/cond-wf-002.cwl
+++ b/tests/conditionals/cond-wf-002.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   val: int
 

--- a/tests/conditionals/cond-wf-002_nojs.cwl
+++ b/tests/conditionals/cond-wf-002_nojs.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   val: int
   test:

--- a/tests/conditionals/cond-wf-003.1.cwl
+++ b/tests/conditionals/cond-wf-003.1.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   val: int
 

--- a/tests/conditionals/cond-wf-003.1_nojs.cwl
+++ b/tests/conditionals/cond-wf-003.1_nojs.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   val:
     type: int

--- a/tests/conditionals/cond-wf-003.cwl
+++ b/tests/conditionals/cond-wf-003.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   val: int
   def:

--- a/tests/conditionals/cond-wf-003_nojs.cwl
+++ b/tests/conditionals/cond-wf-003_nojs.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   val:
     type: int

--- a/tests/conditionals/cond-wf-004.cwl
+++ b/tests/conditionals/cond-wf-004.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   val: int
   def:

--- a/tests/conditionals/cond-wf-004_nojs.cwl
+++ b/tests/conditionals/cond-wf-004_nojs.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   val:
     type: int

--- a/tests/conditionals/cond-wf-005.cwl
+++ b/tests/conditionals/cond-wf-005.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   val: int
   def:

--- a/tests/conditionals/cond-wf-005_nojs.cwl
+++ b/tests/conditionals/cond-wf-005_nojs.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   test: boolean
   val:

--- a/tests/conditionals/cond-wf-006.cwl
+++ b/tests/conditionals/cond-wf-006.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   val: int
 

--- a/tests/conditionals/cond-wf-006_nojs.cwl
+++ b/tests/conditionals/cond-wf-006_nojs.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   test1: boolean
   test2: boolean

--- a/tests/conditionals/cond-wf-007.cwl
+++ b/tests/conditionals/cond-wf-007.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   val: int
 

--- a/tests/conditionals/cond-wf-007_nojs.cwl
+++ b/tests/conditionals/cond-wf-007_nojs.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   val:
    type: int

--- a/tests/conditionals/cond-wf-009.cwl
+++ b/tests/conditionals/cond-wf-009.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   data: int[]
   val: int

--- a/tests/conditionals/cond-wf-009_nojs.cwl
+++ b/tests/conditionals/cond-wf-009_nojs.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   data:
     type: int[]

--- a/tests/conditionals/cond-wf-010.cwl
+++ b/tests/conditionals/cond-wf-010.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   val: int[]
 

--- a/tests/conditionals/cond-wf-010_nojs.cwl
+++ b/tests/conditionals/cond-wf-010_nojs.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   val:
     type: int[]

--- a/tests/conditionals/cond-wf-011.cwl
+++ b/tests/conditionals/cond-wf-011.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   in1: int[]
   in2: int[]

--- a/tests/conditionals/cond-wf-011_nojs.cwl
+++ b/tests/conditionals/cond-wf-011_nojs.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   in1:
     type: int[]

--- a/tests/conditionals/cond-wf-012.cwl
+++ b/tests/conditionals/cond-wf-012.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   val: int
 

--- a/tests/conditionals/cond-wf-012_nojs.cwl
+++ b/tests/conditionals/cond-wf-012_nojs.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   val:
     type: int

--- a/tests/conditionals/cond-wf-013.cwl
+++ b/tests/conditionals/cond-wf-013.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   in1: int[]
 

--- a/tests/conditionals/cond-wf-013_nojs.cwl
+++ b/tests/conditionals/cond-wf-013_nojs.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   in1:
     type: int[]

--- a/tests/conditionals/cond-with-defaults.cwl
+++ b/tests/conditionals/cond-with-defaults.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   MultipleInputFeatureRequirement: {}

--- a/tests/conditionals/foo.cwl
+++ b/tests/conditionals/foo.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   in1: int
 baseCommand: [echo]

--- a/tests/conflict-wf.cwl
+++ b/tests/conflict-wf.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 $graph:
 - id: echo
   class: CommandLineTool

--- a/tests/cores_float.cwl
+++ b/tests/cores_float.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   ResourceRequirement:

--- a/tests/count-lines1-wf-noET.cwl
+++ b/tests/count-lines1-wf-noET.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   file1:

--- a/tests/count-lines1-wf.cwl
+++ b/tests/count-lines1-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   file1:

--- a/tests/count-lines10-wf.cwl
+++ b/tests/count-lines10-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   file1: File
 outputs:

--- a/tests/count-lines11-extra-step-wf-noET.cwl
+++ b/tests/count-lines11-extra-step-wf-noET.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   file1: File?

--- a/tests/count-lines11-extra-step-wf.cwl
+++ b/tests/count-lines11-extra-step-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   file1: File?

--- a/tests/count-lines11-null-step-wf-noET.cwl
+++ b/tests/count-lines11-null-step-wf-noET.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs: []
 

--- a/tests/count-lines11-null-step-wf.cwl
+++ b/tests/count-lines11-null-step-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs: []
 

--- a/tests/count-lines11-wf-noET.cwl
+++ b/tests/count-lines11-wf-noET.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   file1: File?

--- a/tests/count-lines11-wf.cwl
+++ b/tests/count-lines11-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   file1: File?

--- a/tests/count-lines12-wf.cwl
+++ b/tests/count-lines12-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   - class: MultipleInputFeatureRequirement
 

--- a/tests/count-lines13-wf.cwl
+++ b/tests/count-lines13-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
     file1: File

--- a/tests/count-lines14-wf.cwl
+++ b/tests/count-lines14-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
     file1:

--- a/tests/count-lines15-wf.cwl
+++ b/tests/count-lines15-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   file1: File
 outputs:

--- a/tests/count-lines16-wf.cwl
+++ b/tests/count-lines16-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   file1: File
 outputs:

--- a/tests/count-lines17-wf.cwl
+++ b/tests/count-lines17-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   file1: File
 outputs:

--- a/tests/count-lines18-wf.cwl
+++ b/tests/count-lines18-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
     file1:

--- a/tests/count-lines19-wf.cwl
+++ b/tests/count-lines19-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
     file1: File

--- a/tests/count-lines2-wf.cwl
+++ b/tests/count-lines2-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InlineJavascriptRequirement: {}
 

--- a/tests/count-lines3-wf.cwl
+++ b/tests/count-lines3-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
     file1:

--- a/tests/count-lines4-wf.cwl
+++ b/tests/count-lines4-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
     file1:

--- a/tests/count-lines5-wf.cwl
+++ b/tests/count-lines5-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
     file1:

--- a/tests/count-lines6-wf.cwl
+++ b/tests/count-lines6-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
     file1: File[]

--- a/tests/count-lines7-wf.cwl
+++ b/tests/count-lines7-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   - class: MultipleInputFeatureRequirement

--- a/tests/count-lines8-wf-noET.cwl
+++ b/tests/count-lines8-wf-noET.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
     file1: File

--- a/tests/count-lines8-wf.cwl
+++ b/tests/count-lines8-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
     file1: File

--- a/tests/count-lines9-wf-noET.cwl
+++ b/tests/count-lines9-wf-noET.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs: []
 

--- a/tests/count-lines9-wf.cwl
+++ b/tests/count-lines9-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs: []
 

--- a/tests/default_path.cwl
+++ b/tests/default_path.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 inputs:
   - id: "file1"

--- a/tests/dir.cwl
+++ b/tests/dir.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   - class: ShellCommandRequirement
 inputs:

--- a/tests/dir2.cwl
+++ b/tests/dir2.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   ShellCommandRequirement: {}
 hints:

--- a/tests/dir3.cwl
+++ b/tests/dir3.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 baseCommand: [tar, xvf]
 inputs:
   inf:

--- a/tests/dir4.cwl
+++ b/tests/dir4.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   - class: ShellCommandRequirement
 inputs:

--- a/tests/dir5.cwl
+++ b/tests/dir5.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   - class: ShellCommandRequirement
   - class: InitialWorkDirRequirement

--- a/tests/dir6.cwl
+++ b/tests/dir6.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   - class: ShellCommandRequirement
 inputs:

--- a/tests/dir7.cwl
+++ b/tests/dir7.cwl
@@ -1,5 +1,5 @@
 class: ExpressionTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InlineJavascriptRequirement: {}
 inputs:

--- a/tests/docker-array-secondaryfiles.cwl
+++ b/tests/docker-array-secondaryfiles.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   - class: DockerRequirement

--- a/tests/docker-output-dir.cwl
+++ b/tests/docker-output-dir.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   DockerRequirement:
     dockerPull: docker.io/debian:stable-slim

--- a/tests/docker-run-cmd.cwl
+++ b/tests/docker-run-cmd.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   DockerRequirement:
     dockerPull: docker.io/bash:4.4

--- a/tests/dynresreq-default.cwl
+++ b/tests/dynresreq-default.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   ResourceRequirement:

--- a/tests/dynresreq-dir.cwl
+++ b/tests/dynresreq-dir.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   InlineJavascriptRequirement: {}

--- a/tests/dynresreq-workflow-inputdefault.cwl
+++ b/tests/dynresreq-workflow-inputdefault.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   special_file:

--- a/tests/dynresreq-workflow-stepdefault.cwl
+++ b/tests/dynresreq-workflow-stepdefault.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   special_file: File?

--- a/tests/dynresreq-workflow-tooldefault.cwl
+++ b/tests/dynresreq-workflow-tooldefault.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   special_file: File?

--- a/tests/dynresreq-workflow.cwl
+++ b/tests/dynresreq-workflow.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   special_file: File

--- a/tests/dynresreq.cwl
+++ b/tests/dynresreq.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   ResourceRequirement:

--- a/tests/echo-file-tool.cwl
+++ b/tests/echo-file-tool.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 baseCommand: [echo]
 inputs:

--- a/tests/echo-position-expr.cwl
+++ b/tests/echo-position-expr.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InlineJavascriptRequirement: {}
 inputs:

--- a/tests/echo-tool-default.cwl
+++ b/tests/echo-tool-default.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   in:
     type: string

--- a/tests/echo-tool-packed.cwl
+++ b/tests/echo-tool-packed.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 $graph:
   - class: CommandLineTool
     id: first

--- a/tests/echo-tool-packed2.cwl
+++ b/tests/echo-tool-packed2.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 $graph:
   - class: CommandLineTool
     id: first

--- a/tests/echo-tool.cwl
+++ b/tests/echo-tool.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   in:
     type: Any

--- a/tests/echo-wf-default.cwl
+++ b/tests/echo-wf-default.cwl
@@ -1,6 +1,6 @@
 
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs: []
 

--- a/tests/empty-array-input.cwl
+++ b/tests/empty-array-input.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 
 hints:

--- a/tests/env-tool1.cwl
+++ b/tests/env-tool1.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   in: string
 outputs:

--- a/tests/env-tool2.cwl
+++ b/tests/env-tool2.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   in: string
 outputs:

--- a/tests/env-tool3.cwl
+++ b/tests/env-tool3.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   in: string
 outputs:

--- a/tests/env-tool4.cwl
+++ b/tests/env-tool4.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   in: string
 outputs:

--- a/tests/env-wf1.cwl
+++ b/tests/env-wf1.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
     in: string

--- a/tests/env-wf2.cwl
+++ b/tests/env-wf2.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
     in: string

--- a/tests/env-wf3.cwl
+++ b/tests/env-wf3.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
     in: string

--- a/tests/envvar.cwl
+++ b/tests/envvar.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs: []
 outputs: []
 requirements:

--- a/tests/envvar2.cwl
+++ b/tests/envvar2.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs: []
 outputs: []
 requirements:

--- a/tests/envvar3.cwl
+++ b/tests/envvar3.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs: []
 outputs:
   results:

--- a/tests/exit-success.cwl
+++ b/tests/exit-success.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 
 inputs: []

--- a/tests/exitcode.cwl
+++ b/tests/exitcode.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 requirements:
   ShellCommandRequirement: {}

--- a/tests/fail-unconnected.cwl
+++ b/tests/fail-unconnected.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   inp1:
     type: string

--- a/tests/fail-unspecified-input.cwl
+++ b/tests/fail-unspecified-input.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   in: string
 outputs:

--- a/tests/file-literal-ex.cwl
+++ b/tests/file-literal-ex.cwl
@@ -1,5 +1,5 @@
 class: ExpressionTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InlineJavascriptRequirement: {}
 inputs: []

--- a/tests/formattest.cwl
+++ b/tests/formattest.cwl
@@ -1,6 +1,6 @@
 $namespaces:
   edam: "http://edamontology.org/"
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 doc: "Reverse each line using the `rev` command"
 inputs:

--- a/tests/formattest2.cwl
+++ b/tests/formattest2.cwl
@@ -3,7 +3,7 @@ $namespaces:
 $schemas:
   - EDAM.owl
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: "Reverse each line using the `rev` command"
 hints:
   DockerRequirement:

--- a/tests/formattest3.cwl
+++ b/tests/formattest3.cwl
@@ -5,7 +5,7 @@ $schemas:
   - EDAM.owl
   - gx_edam.ttl
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: "Reverse each line using the `rev` command"
 hints:
   DockerRequirement:

--- a/tests/glob-expr-list.cwl
+++ b/tests/glob-expr-list.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   ids:

--- a/tests/glob-path-error.cwl
+++ b/tests/glob-path-error.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   - class: DockerRequirement

--- a/tests/glob_directory.cwl
+++ b/tests/glob_directory.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 
 inputs: []

--- a/tests/glob_test.cwl
+++ b/tests/glob_test.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 
 inputs: []

--- a/tests/imported-hint.cwl
+++ b/tests/imported-hint.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 inputs: []
 outputs:

--- a/tests/initialwork-path.cwl
+++ b/tests/initialwork-path.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InitialWorkDirRequirement:
     listing:

--- a/tests/initialworkdir-glob-fullpath.cwl
+++ b/tests/initialworkdir-glob-fullpath.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   - class: InitialWorkDirRequirement

--- a/tests/initialworkdirrequirement-docker-out.cwl
+++ b/tests/initialworkdirrequirement-docker-out.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   - class: DockerRequirement

--- a/tests/inline-js.cwl
+++ b/tests/inline-js.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 
 requirements:

--- a/tests/inp_update_wf.cwl
+++ b/tests/inp_update_wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs: []
 outputs:
   a:

--- a/tests/inpdir_update_wf.cwl
+++ b/tests/inpdir_update_wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs: []
 requirements:
   InlineJavascriptRequirement: {}

--- a/tests/io-any-1.cwl
+++ b/tests/io-any-1.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
  - class: InlineJavascriptRequirement
 

--- a/tests/io-any-wf-1.cwl
+++ b/tests/io-any-wf-1.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   bar:

--- a/tests/io-file-default-wf.cwl
+++ b/tests/io-file-default-wf.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 inputs:

--- a/tests/io-file-or-files.cwl
+++ b/tests/io-file-or-files.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/tests/io-int-default-tool-and-wf.cwl
+++ b/tests/io-int-default-tool-and-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/tests/io-int-default-wf.cwl
+++ b/tests/io-int-default-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/tests/io-int-optional-wf.cwl
+++ b/tests/io-int-optional-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/tests/io-int-wf.cwl
+++ b/tests/io-int-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/tests/io-union-input-default-wf.cwl
+++ b/tests/io-union-input-default-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/tests/iwd/iwd-container-entryname1.cwl
+++ b/tests/iwd/iwd-container-entryname1.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 doc: |
   When executing in a container, entryname can have an absolute path

--- a/tests/iwd/iwd-container-entryname2.cwl
+++ b/tests/iwd/iwd-container-entryname2.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 doc: |
   Must fail if entryname is an absolute path and DockerRequirement is

--- a/tests/iwd/iwd-container-entryname3.cwl
+++ b/tests/iwd/iwd-container-entryname3.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 doc: |
   Must fail if entryname is an absolute path and DockerRequirement is

--- a/tests/iwd/iwd-container-entryname4.cwl
+++ b/tests/iwd/iwd-container-entryname4.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 doc: |
   Must fail if entryname starts with ../

--- a/tests/iwd/iwd-fileobjs1.cwl
+++ b/tests/iwd/iwd-fileobjs1.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: Can have a file declared directly in InitialWorkDir
 requirements:
   InitialWorkDirRequirement:

--- a/tests/iwd/iwd-fileobjs2.cwl
+++ b/tests/iwd/iwd-fileobjs2.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: Can have a file declared directly in InitialWorkDir
 requirements:
   InitialWorkDirRequirement:

--- a/tests/iwd/iwd-jsondump1-nl.cwl
+++ b/tests/iwd/iwd-jsondump1-nl.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InlineJavascriptRequirement: {}
   InitialWorkDirRequirement:

--- a/tests/iwd/iwd-jsondump1.cwl
+++ b/tests/iwd/iwd-jsondump1.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InlineJavascriptRequirement: {}
   InitialWorkDirRequirement:

--- a/tests/iwd/iwd-jsondump2-nl.cwl
+++ b/tests/iwd/iwd-jsondump2-nl.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InlineJavascriptRequirement: {}
   InitialWorkDirRequirement:

--- a/tests/iwd/iwd-jsondump2.cwl
+++ b/tests/iwd/iwd-jsondump2.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InlineJavascriptRequirement: {}
   InitialWorkDirRequirement:

--- a/tests/iwd/iwd-jsondump3-nl.cwl
+++ b/tests/iwd/iwd-jsondump3-nl.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InlineJavascriptRequirement: {}
   InitialWorkDirRequirement:

--- a/tests/iwd/iwd-jsondump3.cwl
+++ b/tests/iwd/iwd-jsondump3.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InlineJavascriptRequirement: {}
   InitialWorkDirRequirement:

--- a/tests/iwd/iwd-nolimit.cwl
+++ b/tests/iwd/iwd-nolimit.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InlineJavascriptRequirement: {}
   InitialWorkDirRequirement:

--- a/tests/iwd/iwd-passthrough1.cwl
+++ b/tests/iwd/iwd-passthrough1.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: |
   YAML |- syntax does not add trailing newline so in the listing entry
   below there is no whitespace surrounding the value

--- a/tests/iwd/iwd-passthrough2.cwl
+++ b/tests/iwd/iwd-passthrough2.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: |
   YAML | syntax adds a trailing newline, so in the listing entry
   below, it becomes a string interpolation -- it evaluates to a string

--- a/tests/iwd/iwd-passthrough3.cwl
+++ b/tests/iwd/iwd-passthrough3.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InitialWorkDirRequirement:
     listing:

--- a/tests/iwd/iwd-passthrough4.cwl
+++ b/tests/iwd/iwd-passthrough4.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InitialWorkDirRequirement:
     listing:

--- a/tests/iwd/iwdr_dir_literal_real_file.cwl
+++ b/tests/iwd/iwdr_dir_literal_real_file.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   DockerRequirement:

--- a/tests/iwdr-entry.cwl
+++ b/tests/iwdr-entry.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 baseCommand: ["cat", "example.conf"]
 
 requirements:

--- a/tests/iwdr_with_nested_dirs.cwl
+++ b/tests/iwdr_with_nested_dirs.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 inputs: []

--- a/tests/js-expr-req-wf.cwl
+++ b/tests/js-expr-req-wf.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 $graph:
   - id: tool
     class: CommandLineTool

--- a/tests/js-input-record.cwl
+++ b/tests/js-input-record.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.0
+cwlVersion: v1.3.0-dev1
 
 class: CommandLineTool
 

--- a/tests/linkfile.cwl
+++ b/tests/linkfile.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 
 requirements:

--- a/tests/listing_deep1.cwl
+++ b/tests/listing_deep1.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   LoadListingRequirement:
     loadListing: deep_listing

--- a/tests/listing_deep2.cwl
+++ b/tests/listing_deep2.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InlineJavascriptRequirement: {}
 inputs:

--- a/tests/listing_none1.cwl
+++ b/tests/listing_none1.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InlineJavascriptRequirement: {}
 inputs:

--- a/tests/listing_none2.cwl
+++ b/tests/listing_none2.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   LoadListingRequirement:
     loadListing: no_listing

--- a/tests/listing_none3.cwl
+++ b/tests/listing_none3.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InlineJavascriptRequirement: {}
 inputs:

--- a/tests/listing_shallow1.cwl
+++ b/tests/listing_shallow1.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   LoadListingRequirement:
     loadListing: shallow_listing

--- a/tests/listing_shallow2.cwl
+++ b/tests/listing_shallow2.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InlineJavascriptRequirement: {}
 inputs:

--- a/tests/listing_shallow3.cwl
+++ b/tests/listing_shallow3.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InlineJavascriptRequirement: {}
 inputs: []

--- a/tests/loadContents/cwloutput-nolimit.cwl
+++ b/tests/loadContents/cwloutput-nolimit.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   DockerRequirement:
     dockerPull: docker.io/python:3-slim

--- a/tests/loadContents/loadContents-limit.cwl
+++ b/tests/loadContents/loadContents-limit.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   filelist:
     type: File

--- a/tests/metadata.cwl
+++ b/tests/metadata.cwl
@@ -6,7 +6,7 @@ $schemas:
   - foaf.rdf
   - dcterms.rdf
 
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 doc: "Test that a command line document with metadata is executed successfully."
 

--- a/tests/mixed-versions/test-index.yaml
+++ b/tests/mixed-versions/test-index.yaml
@@ -7,22 +7,93 @@
 - job: null
   tool: wf-v10.cwl
   id: mixed_version_v10_wf
-  output: {}
+  output:
+    result0:
+      class: File
+      checksum: sha1$1d6d222b15f3cf2308a6c09ab199fa8ca3f65c66
+      size: 10
+    result1:
+      class: File
+      checksum: sha1$1d6d222b15f3cf2308a6c09ab199fa8ca3f65c66
+      size: 10
+    result2:
+      class: File
+      checksum: sha1$1d6d222b15f3cf2308a6c09ab199fa8ca3f65c66
+      size: 10
+    result3:
+      class: File
+      checksum: sha1$1d6d222b15f3cf2308a6c09ab199fa8ca3f65c66
+      size: 10
   doc: test v1.0 workflow document that runs other versions
   tags: [ workflow ]
 
 - job: null
   tool: wf-v11.cwl
   id: mixed_version_v11_wf
-  output: {}
+  output:
+    result0:
+      class: File
+      checksum: sha1$1d6d222b15f3cf2308a6c09ab199fa8ca3f65c66
+      size: 10
+    result1:
+      class: File
+      checksum: sha1$1d6d222b15f3cf2308a6c09ab199fa8ca3f65c66
+      size: 10
+    result2:
+      class: File
+      checksum: sha1$1d6d222b15f3cf2308a6c09ab199fa8ca3f65c66
+      size: 10
+    result3:
+      class: File
+      checksum: sha1$1d6d222b15f3cf2308a6c09ab199fa8ca3f65c66
+      size: 10
   doc: test v1.1 workflow document that runs other versions
   tags: [ workflow ]
 
 - job: null
   tool: wf-v12.cwl
   id: mixed_version_v12_wf
-  output: {}
+  output:
+    result0:
+      class: File
+      checksum: sha1$1d6d222b15f3cf2308a6c09ab199fa8ca3f65c66
+      size: 10
+    result1:
+      class: File
+      checksum: sha1$1d6d222b15f3cf2308a6c09ab199fa8ca3f65c66
+      size: 10
+    result2:
+      class: File
+      checksum: sha1$1d6d222b15f3cf2308a6c09ab199fa8ca3f65c66
+      size: 10
+    result3:
+      class: File
+      checksum: sha1$1d6d222b15f3cf2308a6c09ab199fa8ca3f65c66
+      size: 10
   doc: test v1.2 workflow document that runs other versions
+  tags: [ workflow ]
+
+- job: null
+  tool: wf-v13.cwl
+  id: mixed_version_v13_wf
+  output:
+    result0:
+      class: File
+      checksum: sha1$1d6d222b15f3cf2308a6c09ab199fa8ca3f65c66
+      size: 10
+    result1:
+      class: File
+      checksum: sha1$1d6d222b15f3cf2308a6c09ab199fa8ca3f65c66
+      size: 10
+    result2:
+      class: File
+      checksum: sha1$1d6d222b15f3cf2308a6c09ab199fa8ca3f65c66
+      size: 10
+    result3:
+      class: File
+      checksum: sha1$1d6d222b15f3cf2308a6c09ab199fa8ca3f65c66
+      size: 10
+  doc: test v1.3.0-dev1 workflow document that runs other versions
   tags: [ workflow ]
 
 - job: null

--- a/tests/mixed-versions/tool-v11.cwl
+++ b/tests/mixed-versions/tool-v11.cwl
@@ -6,5 +6,6 @@ inputs:
     secondaryFiles:
       - pattern: ".2"
         required: true
-outputs: []
-arguments: [echo, $(inputs.inp1)]
+outputs:
+ result: stdout
+arguments: [echo, $(inputs.inp1.basename)]

--- a/tests/mixed-versions/tool-v12.cwl
+++ b/tests/mixed-versions/tool-v12.cwl
@@ -9,5 +9,6 @@ inputs:
 requirements:
   ResourceRequirement:
     coresMin: .5
-outputs: []
-arguments: [echo, $(inputs.inp1)]
+outputs:
+ result: stdout
+arguments: [echo, $(inputs.inp1.basename)]

--- a/tests/mixed-versions/tool-v13.cwl
+++ b/tests/mixed-versions/tool-v13.cwl
@@ -1,10 +1,14 @@
-cwlVersion: v1.0
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 inputs:
   inp1:
     type: File
     secondaryFiles:
-      - ".2"
+      - pattern: ".2"
+        required: true
+requirements:
+  ResourceRequirement:
+    coresMin: .5
 outputs:
  result: stdout
 arguments: [echo, $(inputs.inp1.basename)]

--- a/tests/mixed-versions/wf-v11.cwl
+++ b/tests/mixed-versions/wf-v11.cwl
@@ -1,5 +1,6 @@
 cwlVersion: v1.1
 class: Workflow
+
 inputs:
   inp1:
     type: File
@@ -9,17 +10,35 @@ inputs:
     default:
       class: File
       location: hello.txt
-outputs: []
+
 steps:
   toolv10:
     in: {inp1: inp1}
-    out: []
+    out: [result]
     run: tool-v10.cwl
   toolv11:
     in: {inp1: inp1}
-    out: []
+    out: [result]
     run: tool-v11.cwl
   toolv12:
     in: {inp1: inp1}
-    out: []
+    out: [result]
     run: tool-v12.cwl
+  toolv13:
+    in: {inp1: inp1}
+    out: [result]
+    run: tool-v13.cwl
+
+outputs:
+  result0:
+    type: File
+    outputSource: toolv10/result
+  result1:
+    type: File
+    outputSource: toolv11/result
+  result2:
+    type: File
+    outputSource: toolv12/result
+  result3:
+    type: File
+    outputSource: toolv13/result

--- a/tests/mixed-versions/wf-v12.cwl
+++ b/tests/mixed-versions/wf-v12.cwl
@@ -1,28 +1,44 @@
 cwlVersion: v1.2
 class: Workflow
-requirements:
-  InlineJavascriptRequirement: {}
+
 inputs:
   inp1:
     type: File
-    default:
-      class: File
-      location: hello.txt
     secondaryFiles:
       - pattern: ".2"
         required: true
-outputs: []
+    default:
+      class: File
+      location: hello.txt
+
 steps:
   toolv10:
     in: {inp1: inp1}
-    out: []
+    out: [result]
     run: tool-v10.cwl
   toolv11:
     in: {inp1: inp1}
-    out: []
+    out: [result]
     run: tool-v11.cwl
   toolv12:
     in: {inp1: inp1}
-    out: []
-    when: $(true)
+    out: [result]
     run: tool-v12.cwl
+  toolv13:
+    in: {inp1: inp1}
+    out: [result]
+    run: tool-v13.cwl
+
+outputs:
+  result0:
+    type: File
+    outputSource: toolv10/result
+  result1:
+    type: File
+    outputSource: toolv11/result
+  result2:
+    type: File
+    outputSource: toolv12/result
+  result3:
+    type: File
+    outputSource: toolv13/result

--- a/tests/mixed-versions/wf-v13.cwl
+++ b/tests/mixed-versions/wf-v13.cwl
@@ -1,11 +1,12 @@
-cwlVersion: v1.0
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 inputs:
   inp1:
     type: File
     secondaryFiles:
-      - ".2"
+      - pattern: ".2"
+        required: true
     default:
       class: File
       location: hello.txt

--- a/tests/mkdir.cwl
+++ b/tests/mkdir.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   dirname: string
 outputs:

--- a/tests/multiple_input_feature_requirement.cwl
+++ b/tests/multiple_input_feature_requirement.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 requirements:

--- a/tests/nameroot.cwl
+++ b/tests/nameroot.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 inputs:
   file1: File

--- a/tests/nested-array.cwl
+++ b/tests/nested-array.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 baseCommand: echo
 inputs:

--- a/tests/networkaccess.cwl
+++ b/tests/networkaccess.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   DockerRequirement:
     dockerPull: docker.io/python:3-slim

--- a/tests/networkaccess2.cwl
+++ b/tests/networkaccess2.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   DockerRequirement:
     dockerPull: docker.io/python:3-slim

--- a/tests/no-inputs-tool.cwl
+++ b/tests/no-inputs-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: "CommandLineTool without inputs."
 hints:
   DockerRequirement:

--- a/tests/no-inputs-wf.cwl
+++ b/tests/no-inputs-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: "Workflow without inputs."
 inputs: []
 outputs: 
@@ -13,7 +13,7 @@ steps:
     out: [output]
     run: 
       class: CommandLineTool
-      cwlVersion: v1.2
+      cwlVersion: v1.3.0-dev1
       doc: "CommandLineTool without inputs."
       hints:
         DockerRequirement:

--- a/tests/no-outputs-tool.cwl
+++ b/tests/no-outputs-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: "CommandLineTool without outputs."
 hints:
   DockerRequirement:

--- a/tests/no-outputs-wf.cwl
+++ b/tests/no-outputs-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: "Workflow without outputs."
 inputs:
   file1: File
@@ -11,7 +11,7 @@ steps:
     out: []
     run: 
       class: CommandLineTool
-      cwlVersion: v1.2
+      cwlVersion: v1.3.0-dev1
       doc: "CommandLineTool without outputs."
       hints:
         DockerRequirement:

--- a/tests/null-defined.cwl
+++ b/tests/null-defined.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 requirements:
   InlineJavascriptRequirement: {}

--- a/tests/null-expression1-tool.cwl
+++ b/tests/null-expression1-tool.cwl
@@ -3,7 +3,7 @@
 class: ExpressionTool
 requirements:
   - class: InlineJavascriptRequirement
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   i1:

--- a/tests/null-expression2-tool.cwl
+++ b/tests/null-expression2-tool.cwl
@@ -3,7 +3,7 @@
 class: ExpressionTool
 requirements:
   - class: InlineJavascriptRequirement
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   i1: Any

--- a/tests/null-expression3-tool.cwl
+++ b/tests/null-expression3-tool.cwl
@@ -2,7 +2,7 @@
 
 class: ExpressionTool
 requirements: { InlineJavascriptRequirement: {} }
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs: []
 

--- a/tests/optional-numerical-output-0.cwl
+++ b/tests/optional-numerical-output-0.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 baseCommand:
   - echo

--- a/tests/output-arrays-file-wf.cwl
+++ b/tests/output-arrays-file-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/tests/output-arrays-int-wf.cwl
+++ b/tests/output-arrays-int-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   InlineJavascriptRequirement: {}

--- a/tests/output-arrays-int.cwl
+++ b/tests/output-arrays-int.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: ExpressionTool
 
 requirements:

--- a/tests/output_reference_workflow_input.cwl
+++ b/tests/output_reference_workflow_input.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 inputs:

--- a/tests/paramref_arguments_roundtrip.cwl
+++ b/tests/paramref_arguments_roundtrip.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.0
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 inputs:
   a_record:

--- a/tests/params.cwl
+++ b/tests/params.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   bar:
     type: Any

--- a/tests/params2.cwl
+++ b/tests/params2.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   - class: InlineJavascriptRequirement  # needed by params_inc.yml
 

--- a/tests/params_broken_length_of_non_list.cwl
+++ b/tests/params_broken_length_of_non_list.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   bar:
     type: Any

--- a/tests/params_broken_null.cwl
+++ b/tests/params_broken_null.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   bar:
     type: Any

--- a/tests/params_input_length_non_array.cwl
+++ b/tests/params_input_length_non_array.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   length:
     type: int

--- a/tests/parseInt-tool.cwl
+++ b/tests/parseInt-tool.cwl
@@ -3,7 +3,7 @@
 class: ExpressionTool
 requirements:
   - class: InlineJavascriptRequirement
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   file1:

--- a/tests/pass-unconnected.cwl
+++ b/tests/pass-unconnected.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   inp1:
     type: string

--- a/tests/record-in-format.cwl
+++ b/tests/record-in-format.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   regular_input:
     type: File

--- a/tests/record-in-secondaryFiles-missing-wf.cwl
+++ b/tests/record-in-secondaryFiles-missing-wf.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   record_input:
     type:

--- a/tests/record-in-secondaryFiles-wf.cwl
+++ b/tests/record-in-secondaryFiles-wf.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   record_input:
     type:

--- a/tests/record-in-secondaryFiles.cwl
+++ b/tests/record-in-secondaryFiles.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   record_input:
     type:

--- a/tests/record-order.cwl
+++ b/tests/record-order.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 baseCommand: python
 inputs:

--- a/tests/record-out-format.cwl
+++ b/tests/record-out-format.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   record_input:
     type:

--- a/tests/record-out-secondaryFiles.cwl
+++ b/tests/record-out-secondaryFiles.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs: []
 outputs:
   record_output:

--- a/tests/record-output-wf.cwl
+++ b/tests/record-output-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   irec:

--- a/tests/record-output.cwl
+++ b/tests/record-output.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   - class: ShellCommandRequirement
 inputs:

--- a/tests/record-sd-secondaryFiles.cwl
+++ b/tests/record-sd-secondaryFiles.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   SchemaDefRequirement:
     types:

--- a/tests/record_outputeval.cwl
+++ b/tests/record_outputeval.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 requirements:
   InlineJavascriptRequirement: {}

--- a/tests/record_outputeval_nojs.cwl
+++ b/tests/record_outputeval_nojs.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 inputs:
   ref:

--- a/tests/recursive-input-directory.cwl
+++ b/tests/recursive-input-directory.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 requirements:
   InitialWorkDirRequirement:

--- a/tests/rename.cwl
+++ b/tests/rename.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 baseCommand: "true"
 requirements:
   InitialWorkDirRequirement:

--- a/tests/revsort.cwl
+++ b/tests/revsort.cwl
@@ -3,7 +3,7 @@
 #
 class: Workflow
 doc: "Reverse the lines in a document, then sort those lines."
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 # Requirements & hints specify prerequisites and extensions to the workflow.
 # In this example, DockerRequirement specifies a default Docker container

--- a/tests/revtool.cwl
+++ b/tests/revtool.cwl
@@ -2,7 +2,7 @@
 # Simplest example command line program wrapper for the Unix tool "rev".
 #
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: "Reverse each line using the `rev` command"
 
 # The "inputs" array defines the structure of the input object that describes

--- a/tests/runtime-outdir.cwl
+++ b/tests/runtime-outdir.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 baseCommand: [bash, -c]
 arguments:

--- a/tests/runtime-paths-distinct.cwl
+++ b/tests/runtime-paths-distinct.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   ShellCommandRequirement: {}
 inputs: {}

--- a/tests/scatter-valueFrom-tool.cwl
+++ b/tests/scatter-valueFrom-tool.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 inputs:
   scattered_message:

--- a/tests/scatter-valuefrom-inputs-wf1.cwl
+++ b/tests/scatter-valuefrom-inputs-wf1.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 inputs:
   inp:

--- a/tests/scatter-valuefrom-wf1.cwl
+++ b/tests/scatter-valuefrom-wf1.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 inputs:
   inp:

--- a/tests/scatter-valuefrom-wf2.cwl
+++ b/tests/scatter-valuefrom-wf2.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 inputs:

--- a/tests/scatter-valuefrom-wf3.cwl
+++ b/tests/scatter-valuefrom-wf3.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 $graph:
 
 - id: echo

--- a/tests/scatter-valuefrom-wf4.cwl
+++ b/tests/scatter-valuefrom-wf4.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 $graph:
 - id: echo
   class: CommandLineTool

--- a/tests/scatter-valuefrom-wf5.cwl
+++ b/tests/scatter-valuefrom-wf5.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 inputs:
   inp:

--- a/tests/scatter-valuefrom-wf6.cwl
+++ b/tests/scatter-valuefrom-wf6.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 requirements:
   - class: ScatterFeatureRequirement

--- a/tests/scatter-wf1.cwl
+++ b/tests/scatter-wf1.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 inputs:
   inp: string[]

--- a/tests/scatter-wf2.cwl
+++ b/tests/scatter-wf2.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 inputs:

--- a/tests/scatter-wf3.cwl
+++ b/tests/scatter-wf3.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 $graph:
 
 - id: echo

--- a/tests/scatter-wf4.cwl
+++ b/tests/scatter-wf4.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 $graph:
 - id: echo
   class: CommandLineTool

--- a/tests/scatter/dotproduct-dotproduct-scatter.cwl
+++ b/tests/scatter/dotproduct-dotproduct-scatter.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 requirements:

--- a/tests/scatter/dotproduct-simple-scatter.cwl
+++ b/tests/scatter/dotproduct-simple-scatter.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 requirements:

--- a/tests/scatter/flat-crossproduct-flat-crossproduct-scatter.cwl
+++ b/tests/scatter/flat-crossproduct-flat-crossproduct-scatter.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 requirements:

--- a/tests/scatter/flat-crossproduct-simple-scatter.cwl
+++ b/tests/scatter/flat-crossproduct-simple-scatter.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 requirements:

--- a/tests/scatter/nested-crossproduct-nested-crossproduct-scatter.cwl
+++ b/tests/scatter/nested-crossproduct-nested-crossproduct-scatter.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 requirements:

--- a/tests/scatter/nested-crossproduct-simple-scatter.cwl
+++ b/tests/scatter/nested-crossproduct-simple-scatter.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 requirements:

--- a/tests/scatter/simple-dotproduct-scatter.cwl
+++ b/tests/scatter/simple-dotproduct-scatter.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 requirements:

--- a/tests/scatter/simple-flat-crossproduct-scatter.cwl
+++ b/tests/scatter/simple-flat-crossproduct-scatter.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 requirements:

--- a/tests/scatter/simple-nested-crossproduct-scatter.cwl
+++ b/tests/scatter/simple-nested-crossproduct-scatter.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 requirements:

--- a/tests/scatter/simple-simple-scatter.cwl
+++ b/tests/scatter/simple-simple-scatter.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 requirements:

--- a/tests/schemadef-tool.cwl
+++ b/tests/schemadef-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   - $import: schemadef-type.yml

--- a/tests/schemadef-wf.cwl
+++ b/tests/schemadef-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 requirements:

--- a/tests/schemadef_types_with_import-tool.cwl
+++ b/tests/schemadef_types_with_import-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/tests/schemadef_types_with_import-wf.cwl
+++ b/tests/schemadef_types_with_import-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 # See https://github.com/jeremiahsavage/cwl_schemadef/, thanks to Jeremiah H. Savage.
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 requirements:

--- a/tests/search.cwl
+++ b/tests/search.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 $graph:
 - id: index
   class: CommandLineTool

--- a/tests/secondaryfiles/rename-inputs.cwl
+++ b/tests/secondaryfiles/rename-inputs.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 id: InputSecondaryFileConformanceTest
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: |
   Simple test to confirm the implementation of expressions returning a File within a CommandInputParameter.secondaryFile field.
 

--- a/tests/secondaryfiles/rename-outputs.cwl
+++ b/tests/secondaryfiles/rename-outputs.cwl
@@ -3,7 +3,7 @@ id: OutputSecondaryFileConformanceTest
 baseCommand:
 - ls
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: |
   Simple test to confirm the implementation of expressions returning a File within a CommandOutputParameter.secondaryFile field.
 

--- a/tests/shellchar.cwl
+++ b/tests/shellchar.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: |
   Ensure that arguments containing shell directives are not interpreted and
   that `shellQuote: false` has no effect when ShellCommandRequirement is not in

--- a/tests/shellchar2.cwl
+++ b/tests/shellchar2.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: |
   Ensure that `shellQuote: true` is the default behavior when
   ShellCommandRequirement is in effect.

--- a/tests/size-expression-tool.cwl
+++ b/tests/size-expression-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/tests/sorttool.cwl
+++ b/tests/sorttool.cwl
@@ -2,7 +2,7 @@
 # demonstrating command line flags.
 class: CommandLineTool
 doc: "Sort lines using the `sort` command"
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 # This example is similar to the previous one, with an additional input
 # parameter called "reverse".  It is a boolean parameter, which is

--- a/tests/stage-array-dirs.cwl
+++ b/tests/stage-array-dirs.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 id: stage_array_dirs
 baseCommand:
   - ls

--- a/tests/stage-array.cwl
+++ b/tests/stage-array.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 id: stage_array
 arguments:
   - {shellQuote: false, valueFrom: "ls | grep -v lsout"}

--- a/tests/stage-unprovided-file.cwl
+++ b/tests/stage-unprovided-file.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 hints:
   - class: DockerRequirement

--- a/tests/stage_file_array.cwl
+++ b/tests/stage_file_array.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 id: stage_file_array
 label: Stage File Array
 arguments: [ls]

--- a/tests/stage_file_array_basename.cwl
+++ b/tests/stage_file_array_basename.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 id: stage_file_array_basename
 label: Stage File Array (with Directory Basename)
 arguments: [ls]

--- a/tests/stage_file_array_basename_and_entryname.cwl
+++ b/tests/stage_file_array_basename_and_entryname.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 id: stage_file_array_basename_and_entryname
 label: Stage File Array (with Directory Basename AND entryname)
 arguments: [ls]

--- a/tests/stagefile.cwl
+++ b/tests/stagefile.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 hints:
   - class: DockerRequirement
     dockerPull: docker.io/python:3-slim

--- a/tests/staging-basename/check.cwl
+++ b/tests/staging-basename/check.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   p: File
   checkname: string

--- a/tests/staging-basename/rename.cwl
+++ b/tests/staging-basename/rename.cwl
@@ -1,5 +1,5 @@
 class: ExpressionTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   f1: File
   newname: string

--- a/tests/staging-basename/wf_ren.cwl
+++ b/tests/staging-basename/wf_ren.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs:
   f1:
     type: File

--- a/tests/stderr-mediumcut.cwl
+++ b/tests/stderr-mediumcut.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: "Test of capturing stderr output in a docker container."
 requirements:
   ShellCommandRequirement: {}

--- a/tests/stderr-shortcut.cwl
+++ b/tests/stderr-shortcut.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: "Test of capturing stderr output."
 requirements:
   ShellCommandRequirement: {}

--- a/tests/stderr.cwl
+++ b/tests/stderr.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: "Test of capturing stderr output."
 requirements:
   ShellCommandRequirement: {}

--- a/tests/stdout_chained_commands.cwl
+++ b/tests/stdout_chained_commands.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 requirements:
   - class: ShellCommandRequirement

--- a/tests/step-valuefrom-wf.cwl
+++ b/tests/step-valuefrom-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   - class: StepInputExpressionRequirement
 

--- a/tests/step-valuefrom2-wf.cwl
+++ b/tests/step-valuefrom2-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   - class: StepInputExpressionRequirement
   - class: InlineJavascriptRequirement

--- a/tests/step-valuefrom3-wf.cwl
+++ b/tests/step-valuefrom3-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   - class: StepInputExpressionRequirement
   - class: InlineJavascriptRequirement

--- a/tests/step-valuefrom4-wf.cwl
+++ b/tests/step-valuefrom4-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   StepInputExpressionRequirement: {}
 

--- a/tests/step-valuefrom5-wf.cwl
+++ b/tests/step-valuefrom5-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   StepInputExpressionRequirement: {}
 

--- a/tests/steplevel-resreq.cwl
+++ b/tests/steplevel-resreq.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   ResourceRequirement:

--- a/tests/storage_float.cwl
+++ b/tests/storage_float.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   ResourceRequirement:

--- a/tests/string-interpolation/bash-dollar-quote.cwl
+++ b/tests/string-interpolation/bash-dollar-quote.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InlineJavascriptRequirement: {}
   InitialWorkDirRequirement:

--- a/tests/string-interpolation/bash-line-continuation-with-expression.cwl
+++ b/tests/string-interpolation/bash-line-continuation-with-expression.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InitialWorkDirRequirement:
     listing:

--- a/tests/string-interpolation/bash-line-continuation.cwl
+++ b/tests/string-interpolation/bash-line-continuation.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InitialWorkDirRequirement:
     listing:

--- a/tests/string-interpolation/js-quote.cwl
+++ b/tests/string-interpolation/js-quote.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 label: Check for a JS quoting bug
 
 requirements:

--- a/tests/sum-wf-noET.cwl
+++ b/tests/sum-wf-noET.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 requirements:

--- a/tests/sum-wf.cwl
+++ b/tests/sum-wf.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 
 requirements:

--- a/tests/symlink-illegal.cwl
+++ b/tests/symlink-illegal.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: "Create a file under /tmp, symlink it to working directory and glob symlink. The executor should NOT resolve this symlink"
 hints:
   DockerRequirement:

--- a/tests/symlink-legal.cwl
+++ b/tests/symlink-legal.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 doc: "Create a file under adir/, symlink it to working directory (./) and glob symlink. The executor should resolve this symlink"
 hints:
   DockerRequirement:

--- a/tests/synth-file.cwl
+++ b/tests/synth-file.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 
 inputs:

--- a/tests/template-tool.cwl
+++ b/tests/template-tool.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 requirements:
   - class: InlineJavascriptRequirement

--- a/tests/test-cwl-out.cwl
+++ b/tests/test-cwl-out.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   - class: ShellCommandRequirement
 hints:

--- a/tests/test-cwl-out2.cwl
+++ b/tests/test-cwl-out2.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   - class: ShellCommandRequirement
 hints:

--- a/tests/test-cwl-out3.cwl
+++ b/tests/test-cwl-out3.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   - class: ShellCommandRequirement
 hints:

--- a/tests/test-cwl-out4.cwl
+++ b/tests/test-cwl-out4.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   - class: ShellCommandRequirement
 hints:

--- a/tests/timelimit-wf.cwl
+++ b/tests/timelimit-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   ToolTimeLimit:

--- a/tests/timelimit.cwl
+++ b/tests/timelimit.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs: []
 outputs: []
 requirements:

--- a/tests/timelimit2-wf.cwl
+++ b/tests/timelimit2-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   ToolTimeLimit:

--- a/tests/timelimit2.cwl
+++ b/tests/timelimit2.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs: []
 outputs: []
 requirements:

--- a/tests/timelimit3-wf.cwl
+++ b/tests/timelimit3-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   ToolTimeLimit:

--- a/tests/timelimit3.cwl
+++ b/tests/timelimit3.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs: []
 outputs: []
 requirements:

--- a/tests/timelimit4-wf.cwl
+++ b/tests/timelimit4-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   ToolTimeLimit:

--- a/tests/timelimit4.cwl
+++ b/tests/timelimit4.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs: []
 outputs: []
 requirements:

--- a/tests/timelimit5.cwl
+++ b/tests/timelimit5.cwl
@@ -1,5 +1,5 @@
 class: ExpressionTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 inputs: []
 outputs:
   status: string

--- a/tests/touch.cwl
+++ b/tests/touch.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 
 hints:

--- a/tests/updatedir_inplace.cwl
+++ b/tests/updatedir_inplace.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InitialWorkDirRequirement:
     listing:

--- a/tests/updateval_inplace.cwl
+++ b/tests/updateval_inplace.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   InitialWorkDirRequirement:
     listing:

--- a/tests/valueFrom-constant.cwl
+++ b/tests/valueFrom-constant.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 hints:
   - class: DockerRequirement

--- a/tests/vf-concat.cwl
+++ b/tests/vf-concat.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 requirements:
   - class: InlineJavascriptRequirement

--- a/tests/wc-tool.cwl
+++ b/tests/wc-tool.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 inputs:
   file1: File

--- a/tests/wc2-tool.cwl
+++ b/tests/wc2-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   - class: InlineJavascriptRequirement
 

--- a/tests/wc3-tool.cwl
+++ b/tests/wc3-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/tests/wc4-tool.cwl
+++ b/tests/wc4-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 requirements:
   - class: InlineJavascriptRequirement
 

--- a/tests/wf-loadContents.cwl
+++ b/tests/wf-loadContents.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 requirements:
   StepInputExpressionRequirement: {}

--- a/tests/wf-loadContents2.cwl
+++ b/tests/wf-loadContents2.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 requirements:
   StepInputExpressionRequirement: {}

--- a/tests/wf-loadContents3.cwl
+++ b/tests/wf-loadContents3.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 requirements:
   StepInputExpressionRequirement: {}

--- a/tests/wf-loadContents4.cwl
+++ b/tests/wf-loadContents4.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: Workflow
 requirements:
   StepInputExpressionRequirement: {}

--- a/tests/writable-dir-docker.cwl
+++ b/tests/writable-dir-docker.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 
 class: CommandLineTool
 

--- a/tests/writable-dir.cwl
+++ b/tests/writable-dir.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2
+cwlVersion: v1.3.0-dev1
 class: CommandLineTool
 requirements:
   InlineJavascriptRequirement: {}


### PR DESCRIPTION
This commit bumps the `cwlVersion` field of all the conformance tests to v1.3.0-dev1, with the exception of the `mixed-versions` ones.