### PR TITLE
Test for ExpressionTool outputs validation

### DIFF
--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -3392,3 +3392,9 @@
     }
   }
   tags: [ required, command_line_tool ]
+
+- id: invalid_expression_tool_output
+  tool: tests/null-expression4-tool.cwl
+  doc: Test that the output objects returned by an ExpressionTool process are validated against the outputs schema.
+  should_fail: true
+  tags: [ inline_javascript, expression_tool ]

--- a/tests/null-expression4-tool.cwl
+++ b/tests/null-expression4-tool.cwl
@@ -7,6 +7,6 @@ cwlVersion: v1.3.0-dev1
 inputs: []
 
 outputs:
-  output: Any?
+  output: Any
 
 expression: "$({'output': null })"


### PR DESCRIPTION
Test that the output objects returned by an ExpressionTool process are validated against the `outputs` schema. This is not true for CWL <= v1.2, and has been fixed for CWL >= v1.3.