### PR TITLE
Add support for markdown report

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -51,6 +51,7 @@ SELF=""
 BADGE=""
 TIMEOUT=""
 TAGS=""
+REPORT_URI="https://github.com/common-workflow-language/cwl-v1.3/tree/main/"
 
 while [ -n "$1" ]
 do
@@ -95,7 +96,7 @@ do
             SELF=1
             ;;
         --badgedir=*)
-            BADGE=$arg
+            BADGE="$arg --baseuri=$REPORT_URI"
             ;;
         --timeout=*)
             TIMEOUT=$arg


### PR DESCRIPTION
This request is to support for markdown report feature that was implemented in https://github.com/common-workflow-language/cwltest/pull/209.

Related:
- For v1.0: https://github.com/common-workflow-language/common-workflow-language/pull/958
- For v1.1: https://github.com/common-workflow-language/cwl-v1.1/pull/85
- For v1.2: https://github.com/common-workflow-language/cwl-v1.2/pull/283