### PR TITLE
Add Defaultable for `CommandInputRecordField`

### DIFF
--- a/Process.yml
+++ b/Process.yml
@@ -61,6 +61,23 @@ $graph:
       jsonldPredicate: "rdfs:label"
       doc: "A short, human-readable label of this object."
 
+- name: Defaultable
+  type: record
+  abstract: true
+  fields:
+    - name: default
+      type: CWLObjectType?
+      jsonldPredicate:
+        _id: "sld:default"
+        _container: "@list"
+        noLinkCheck: true
+      doc: |
+        The default value for this parameter.  When it occurs in a CommandLineTool,
+        it is used if the parameter is missing from the input object, or if the value
+        of the parameter in the input object is `null`.  When it occurs in a Workflow,
+        it is used if there is no `source` field, or the value produced by the `source`
+        is `null`.  Default values are applied before scattering or evaluating expressions
+        (e.g. dependent `valueFrom` fields).
 
 - name: Identified
   type: record
@@ -115,24 +132,6 @@ $graph:
           1. `loadListing` on an individual parameter
           2. Inherited from `LoadListingRequirement`
           3. By default: `no_listing`
-
-- name: Defaultable
-  type: record
-  abstract: true
-  fields:
-    - name: default
-      type: CWLObjectType?
-      jsonldPredicate:
-        _id: "sld:default"
-        _container: "@list"
-        noLinkCheck: true
-      doc: |
-        The default value for this parameter.  When it occurs in a CommandLineTool,
-        it is used if the parameter is missing from the input object, or if the value
-        of the parameter in the input object is `null`.  When it occurs in a Workflow,
-        it is used if there is no `source` field, or the value produced by the `source`
-        is `null`.  Default values are applied before scattering or evaluating expressions
-        (e.g. dependent `valueFrom` fields).
 
 - name: FieldBase
   type: record

--- a/Process.yml
+++ b/Process.yml
@@ -116,6 +116,24 @@ $graph:
           2. Inherited from `LoadListingRequirement`
           3. By default: `no_listing`
 
+- name: Defaultable
+  type: record
+  abstract: true
+  fields:
+    - name: default
+      type: CWLObjectType?
+      jsonldPredicate:
+        _id: "sld:default"
+        _container: "@list"
+        noLinkCheck: true
+      doc: |
+        The default value for this parameter.  When it occurs in a CommandLineTool,
+        it is used if the parameter is missing from the input object, or if the value
+        of the parameter in the input object is `null`.  When it occurs in a Workflow,
+        it is used if there is no `source` field, or the value produced by the `source`
+        is `null`.  Default values are applied before scattering or evaluating expressions
+        (e.g. dependent `valueFrom` fields).
+
 - name: FieldBase
   type: record
   extends: Labeled
@@ -286,7 +304,7 @@ $graph:
 
 - name: InputRecordField
   type: record
-  extends: [CWLRecordField, FieldBase, InputFormat, LoadContents]
+  extends: [CWLRecordField, FieldBase, InputFormat, LoadContents, Defaultable]
   specialize:
     - specializeFrom: CWLRecordSchema
       specializeTo: InputRecordSchema
@@ -372,19 +390,7 @@ $graph:
 - name: InputParameter
   type: record
   abstract: true
-  extends: [Parameter, InputFormat, LoadContents]
-  fields:
-    - name: default
-      type: CWLObjectType?
-      jsonldPredicate:
-        _id: "sld:default"
-        _container: "@list"
-        noLinkCheck: true
-      doc: |
-        The default value to use for this parameter if the parameter is missing
-        from the input object, or if the value of the parameter in the input
-        object is `null`.  Default values are applied before evaluating expressions
-        (e.g. dependent `valueFrom` fields).
+  extends: [Parameter, InputFormat, LoadContents, Defaultable]
 
 
 - name: OutputParameter

--- a/Workflow.yml
+++ b/Workflow.yml
@@ -274,7 +274,7 @@ $graph:
 
 - type: record
   name: WorkflowStepInput
-  extends: [Identified, InputSink, LoadContents, Labeled]
+  extends: [Identified, InputSink, LoadContents, Labeled, Defaultable]
   docParent: "#WorkflowStep"
   doc: |
     The input of a workflow step connects an upstream parameter (from the
@@ -387,16 +387,6 @@ $graph:
        should be filtered out.
 
   fields:
-    - name: default
-      type: CWLObjectType?
-      doc: |
-        The default value for this parameter to use if either there is no
-        `source` field, or the value produced by the `source` is `null`.  The
-        default must be applied prior to scattering or evaluating `valueFrom`.
-      jsonldPredicate:
-        _id: "sld:default"
-        _container: "@list"
-        noLinkCheck: true
     - name: valueFrom
       type:
         - "null"

--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -3527,7 +3527,7 @@
       an_int: 42
 
 - id: record_default_field
-  job: tests/empty:json
+  job: tests/empty.json
   tool: tests/record-default-field.cwl
   doc: handling default value in fields of a record object
   tags: [ required, command_line_tool ]

--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -3525,3 +3525,12 @@
       an_array_of_mixed_booleans: [ false, true, false ]
       an_array_of_trues: [ true, true, true ]
       an_int: 42
+
+- id: record_default_field
+  job: tests/empty:json
+  tool: tests/record-default-field.cwl
+  doc: handling default value in fields of a record object
+  tags: [ required, command_line_tool ]
+  output:
+    v1: f1
+    v2: f2

--- a/tests/record-default-field.cwl
+++ b/tests/record-default-field.cwl
@@ -1,0 +1,23 @@
+cwlVersion: v1.3.0-dev1
+class: CommandLineTool
+inputs:
+  record_input:
+    type:
+      type: record
+      fields:
+        f1:
+          type: string
+          default: "f1"
+        f2:
+          type: string
+          default: "f2"
+arguments: ['true']
+outputs:
+    v1:
+        type: string
+        outputBinding:
+            outputEval: $(inputs.record_input.f1)
+    v2:
+        type: string
+        outputBinding:
+            outputEval: $(inputs.record_input.f2)


### PR DESCRIPTION
This request is re-done of common-workflow-language/cwl-v1.1#20 to fix common-workflow-language/common-workflow-language#641.
I introduced `Defaultable` and made it a parent record of `InputParameter`, `WorkflowStepInput` and `InputRecordField`.
I also add a conformance test for it.

I changed the description of `Defaultable#default` by combining descriptions of `InputParameter#default` and `WorkflowStepInput#default`.
Please let me know if there are better descriptions to unifying other descriptions of the `default` field.

Here is a list to be done (copied from common-workflow-language/cwl-v1.1#20):

- [x] one or more conformance tests
- [ ] testing with `cwltool --enable-dev` in a `v1.3.0-dev1` document
   - [ ] add this test permanently 
  - [ ] Okay, need to teach `cwltool` how to copy the default value over
  - [ ] update the spec
- [ ] test `cwltool` using `v1.0`, `v1.1` and `v1.2` and a record field default (this should fail)
   - [ ] add this test permanently