### PR TITLE
Add test on optional (empty) list

### DIFF
--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -872,6 +872,20 @@
     Test optional output file and optional secondaryFile on output.
   tags: [ docker, command_line_tool ]
 
+- tool: tests/optional-list-output.cwl
+  job: tests/any-type-job.json
+  output:
+    files: null
+    log:
+        location: output.txt
+        size: 6
+        class: "File"
+        checksum: "sha1$f572d396fae9206628714fb2ce00f72e94f2258f"
+  id: output_optional_list
+  doc: >-
+    Test optional list of files.
+  tags: [ command_line_tool ]
+
 - job: tests/empty.json
   output:
     out: "\n"

--- a/tests/optional-list-output.cwl
+++ b/tests/optional-list-output.cwl
@@ -1,0 +1,18 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.3.0-dev1
+inputs:
+  input3:
+    type: string
+    inputBinding: {position: 1}
+outputs:
+  log:
+    type: File
+    outputBinding:
+      glob: output.txt
+  files:
+    type: File[]?
+    outputBinding:
+      glob: bumble*.txt
+baseCommand: echo
+stdout: output.txt


### PR DESCRIPTION
This commit adds a test for an optional list. It verifies that when the list is empty, null is propagated instead of an empty list