### PR TITLE
Improved test on optional glob result

### DIFF
--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -875,7 +875,8 @@
 - tool: tests/optional-list-output.cwl
   job: tests/any-type-job.json
   output:
-    files: null
+    files_opt: null
+    files_empty: []
     log:
         location: output.txt
         size: 6

--- a/design-documents/conditionals-2019.md
+++ b/design-documents/conditionals-2019.md
@@ -285,8 +285,8 @@ consistency.
 
 A proposal for a new process object ([`Switch`](https://github.com/common-workflow-language/common-workflow-language/issues/789)) was considered. Preliminary experimentation
 with the syntax raised the complaint that it was quite verbose and unwieldy
-for the most common use cases, which were to by-pass a step. As can be seen
-from the example above, which implements this common by-pass pattern, the
+for the most common use cases, which were to bypass a step. As can be seen
+from the example above, which implements this common bypass pattern, the
 `runIf` syntax is quite succinct and explicit for this use case.
 
 There are two attractions to using a process object from a language safety

--- a/tests/optional-list-output.cwl
+++ b/tests/optional-list-output.cwl
@@ -10,8 +10,12 @@ outputs:
     type: File
     outputBinding:
       glob: output.txt
-  files:
+  files_opt:
     type: File[]?
+    outputBinding:
+      glob: bumble*.txt
+  files_empty:
+    type: File[]
     outputBinding:
       glob: bumble*.txt
 baseCommand: echo


### PR DESCRIPTION
Improve unreleased test case to cover empty globs for mandatory outputs. This case differs from the existing optional output coverage.