### PR TITLE
Add test to skip nested subworkflow

### DIFF
--- a/tests/conditionals/cond-job3.yaml
+++ b/tests/conditionals/cond-job3.yaml
@@ -1,0 +1,4 @@
+file1:
+  class: File
+  location: ../whale.txt
+val: false

--- a/tests/conditionals/cond-wf-014.cwl
+++ b/tests/conditionals/cond-wf-014.cwl
@@ -1,0 +1,43 @@
+class: Workflow
+cwlVersion: v1.3.0-dev1
+inputs:
+  val: boolean
+  file1: File
+steps:
+  nested:
+    run:
+      class: Workflow
+      inputs:
+        file1: File
+      outputs:
+        count_output:
+          type: int
+          outputSource: step2/output
+        wc_output:
+          type: File
+          outputSource: step1/output
+      steps:
+        step1:
+          run: ../wc-tool.cwl
+          in:
+            file1: file1
+          out: [output]
+        step2:
+          run: ../parseInt-tool.cwl
+          in:
+            file1: step1/output
+          out: [output]
+    in:
+      file1: file1
+      val: val
+    out: [count_output, wc_output]
+    when: $(inputs.val)
+outputs:
+  out1:
+    type: int?
+    outputSource: nested/count_output
+  out2:
+    type: File?
+    outputSource: nested/wc_output
+requirements:
+  SubworkflowFeatureRequirement: {}

--- a/tests/conditionals/test-index.yaml
+++ b/tests/conditionals/test-index.yaml
@@ -412,3 +412,12 @@
         }
     ]
   tags: [ conditional, scatter, multiple_input, workflow ]
+
+- id: cond-with-nested-workflows
+  doc: "Skip an entire nested subworkflow"
+  tool: cond-wf-014.cwl
+  job: cond-job3.yaml
+  output:
+    out1: null
+    out2: null
+  tags: [ conditional, workflow, subworkflow ]


### PR DESCRIPTION
This commit adds a test to check if a nested workflow is correctly skipped when the outer `when` condition returns False. In particular, it checks that `None` values are only propagated to the workflow outputs, and not to the inputs of the inner steps.